### PR TITLE
simple flask api

### DIFF
--- a/api.py
+++ b/api.py
@@ -17,7 +17,6 @@ class API:
     app = None
 
     def __init__(self, ghoust):
-        self.thread = None
         self.ghoust = ghoust
         self.app = self.create_app()
 
@@ -38,19 +37,29 @@ class API:
         def ghoust():
             return str(self.ghoust)
 
+        @app.route("/games")
+        def games():
+            return jsonify({
+                "gamemodes": self.ghoust.gamemodes,
+                "activegames": self.ghoust.activegames
+            })
+
         return app
 
     def _run(self):
+        """ Just runs the Flask app """
         port = int(os.environ.get("GHOUST_API_PORT", 8080))
         self.app.run(host="0.0.0.0", port=port)
 
     def run(self, debug=True, threaded=False):
+        """ Runs the Flask app with specific settings """
         if threaded and debug:
             raise Exception("API cannot run threaded with debug=True")
 
         if debug:
-            self.app.config.update(dict(DEBUG=debug))
+            self.app.config.update(dict(DEBUG=True))
             self._run()
+            return
 
         elif threaded:
              thread = threading.Thread(target=self._run)

--- a/api.py
+++ b/api.py
@@ -1,0 +1,68 @@
+"""
+API for the web frontend for the ghoust game Python service.
+
+See also https://www.python-boilerplate.com/flask
+"""
+import os
+import threading
+
+from flask import Flask, jsonify, send_file, request
+from flask_cors import CORS
+
+
+class API:
+    # `ghoust` is a reference to the main Ghoust object,
+    # in order to access data from the handlers
+    ghoust = None
+    app = None
+
+    def __init__(self, ghoust):
+        self.thread = None
+        self.ghoust = ghoust
+        self.app = self.create_app()
+
+    def create_app(self):
+        """ Creates the Flask app """
+        app = Flask(__name__)
+        app.config.update(dict(DEBUG=False))
+
+        # Setup cors headers to allow all domains
+        CORS(app)
+
+        # Definition of the routes.
+        @app.route("/")
+        def hello_world():
+            return "Hello World"
+
+        @app.route("/ghoust")
+        def ghoust():
+            return str(self.ghoust)
+
+        return app
+
+    def _run(self):
+        port = int(os.environ.get("GHOUST_API_PORT", 8080))
+        self.app.run(host="0.0.0.0", port=port)
+
+    def run(self, debug=True, threaded=False):
+        if threaded and debug:
+            raise Exception("API cannot run threaded with debug=True")
+
+        if debug:
+            self.app.config.update(dict(DEBUG=debug))
+            self._run()
+
+        elif threaded:
+             thread = threading.Thread(target=self._run)
+             thread.daemon = True
+             thread.start()
+             return thread
+
+
+if __name__ == "__main__":
+    api = API("123")
+    api.run()
+
+    # thread = api.run(threaded=True, debug=False)
+    # print("thread", thread)
+    # thread.join()

--- a/ghoust_srv.py
+++ b/ghoust_srv.py
@@ -30,12 +30,13 @@ class GHOUST:
 
         # game modules
         self.games = []
+        self.activegames = []
         self.setgames(game_list)
-        gstring = []
+
+        self.gamemodes = []
         for i,m, ispkg in pkgutil.walk_packages(path="games/."):
             if 'games.' in m:
-                gstring.append(m[6:])
-        self.gamemodes = ','.join(gstring)
+                self.gamemodes.append(m[6:])
 
         self.api = API(self)
 
@@ -47,8 +48,9 @@ class GHOUST:
             g.stop()
 
         self.games = []
+        self.activegames = []
+
         # start new games
-        gstring = []
         if self.join_mode == "auto":
             game_list = game_list[:1]
 
@@ -58,14 +60,11 @@ class GHOUST:
             game = C(i)
             game.setup()
             self.games.append(game)
-            gstring.append("{}:{}".format(i, g))
+            self.activegames.append("{}:{}".format(i, g))
 
         if self.join_mode == "auto":
             for _,p in self.clients.items():
                 p.set_game(self.games[0])
-
-        self.activegames = ','.join(gstring)
-        self.client.publish("GHOUST/server/status/activegames", self.activegames, retain=True)
 
     # buzzer, vibro val: [0-1023, 0-1023], [duration (ms), frequency (hz)]
     # led val: [0-1023, 0-1023, 0-10123], [r, g, b]
@@ -181,9 +180,11 @@ class GHOUST:
                 print("retrying after 10s")
                 time.sleep(10)
 
+        mqtt_game_modes_list = ','.join(self.gamemodes)
+        mqtt_active_games = ','.join(self.activegames)
         self.client.publish("GHOUST/server/status", "ACTIVE")
-        self.client.publish("GHOUST/server/status/activegames", self.activegames, retain=True)
-        self.client.publish("GHOUST/server/status/gamemodes", self.gamemodes, retain=True)
+        self.client.publish("GHOUST/server/status/activegames", mqtt_active_games, retain=True)
+        self.client.publish("GHOUST/server/status/gamemodes", mqtt_game_modes_list, retain=True)
 
 
         self.client.loop_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 paho-mqtt==1.2.3
+Flask==0.12.2
+flask-cors==3.0.2


### PR DESCRIPTION
Simple API with [Flask](https://www.python-boilerplate.com/flask)

Runs in a background thread and has access to the Ghoust object. The routes can access the ghoust object with `self.ghoust` as seen here: [api.py#L41](https://github.com/Ghoust-game/ghoust/blob/rest-api/api.py#L41)

By default it runs on port 8080, but this can be set with the `GHOUST_API_PORT` environment variable.

Example curl request:

    $ curl localhost:8080/games
    {
    "activegames": [
        "0:ghoust_game"
    ],
    "gamemodes": [
        "ghoust_chooseteamgame",
        "ghoust_game",
        "ghoust_slowpoke",
        "ghoust_sort",
        "ghoust_teamgame",
        "template_game"
    ]
    }

See the controller here: [api.py#L41](https://github.com/Ghoust-game/ghoust/blob/rest-api/api.py#L41)